### PR TITLE
map_rows function

### DIFF
--- a/ui/src/page/title.rs
+++ b/ui/src/page/title.rs
@@ -42,10 +42,11 @@ pub fn update(msg: Msg, model: &mut Model) {
 
 pub fn view(model: &Model) -> Vec<Node<Msg>> {
     row::many(vec![
-        row::single(text("FIGHT LINES")).center(true),
-        row::single(button("Start", Msg::StartClicked).view()).center(true),
-        row::single(go_view(model.clicked)).center(true),
+        row::single(text("FIGHT LINES")),
+        row::single(button("Start", Msg::StartClicked).view()),
+        row::single(go_view(model.clicked)),
     ])
+    .map_rows(|row| row.center(true))
     .view()
 }
 

--- a/ui/src/view/grid/row.rs
+++ b/ui/src/view/grid/row.rs
@@ -56,8 +56,11 @@ impl<T> Row<T> {
 
 impl<T> Many<T> {
     pub fn view(self) -> Vec<Node<T>> {
-        let iter_rows = self.rows.into_iter();
+        self.rows.into_iter().map(|row| row.view()).collect()
+    }
 
-        iter_rows.map(|row| row.view()).collect()
+    pub fn map_rows(mut self, f: fn(Row<T>) -> Row<T>) -> Many<T> {
+        self.rows = self.rows.into_iter().map(f).collect();
+        self
     }
 }


### PR DESCRIPTION
I was fighting with the compiler for a while trying to implement this, but I finally got it.

`row::many().map_rows` takes a function of type `Row<T> -> Row<T>` and then applies it to every `Row<T>` inside of the `row::Many<T>`

So, in this case, rather than saying `center(true)` for every row, we can do it once on the `row::Many<T>`.